### PR TITLE
Add User#take_associations_from to simplify merging two users

### DIFF
--- a/app/models/open_conference_ware/user.rb
+++ b/app/models/open_conference_ware/user.rb
@@ -256,6 +256,14 @@ module OpenConferenceWare
       return self.proposals.confirmed
     end
 
+    # For use in merging duplicate user records
+    def take_associations_from(dup)
+      dup.authentications.each { |a| self.authentications << a }
+      dup.proposals.each { |p| p.add_user(self); p.remove_user(dup) }
+      dup.user_favorites.each { |f| self.user_favorites << f }
+      dup.selector_votes.each { |v| self.selector_votes << v }
+    end
+
   protected
 
     # Does this user require an email to be defined?

--- a/app/models/open_conference_ware/user.rb
+++ b/app/models/open_conference_ware/user.rb
@@ -258,10 +258,10 @@ module OpenConferenceWare
 
     # For use in merging duplicate user records
     def take_associations_from(dup)
-      dup.authentications.each { |a| self.authentications << a }
+      self.authentications += dup.authentications
+      self.user_favorites += dup.user_favorites
+      self.selector_votes += dup.selector_votes
       dup.proposals.each { |p| p.add_user(self); p.remove_user(dup) }
-      dup.user_favorites.each { |f| self.user_favorites << f }
-      dup.selector_votes.each { |v| self.selector_votes << v }
     end
 
   protected

--- a/spec/fixtures/open_conference_ware_users.yml
+++ b/spec/fixtures/open_conference_ware_users.yml
@@ -85,3 +85,15 @@ aaron:
 incognito:
   created_at: <%= 1.days.ago.to_s :db %>
   complete_profile: false
+
+# An almost duplicate of user quentin
+quentin2:
+  proposals: bigtable_session, couchdb_session
+  email: "example@quentin.com"
+  first_name: "Quentin"
+  last_name: "Tarantino"
+  created_at: <%= 2.days.ago.to_s :db %>
+  complete_profile: true
+  biography: |
+    I'm called Quentin, French form of the Roman name Quintinus.
+


### PR DESCRIPTION
Make it easier to merge duplicate users: use this new method in the console to automatically merge a user's authentications, proposals, user_favorites, and selector_votes.

The other user fields (email, names, website, photo, admin flag, etc) still need to be merged by hand:
1) Make sure all fields are correct on `user1`.
2) `user1.take_associations_from(user2)`
3) `user2` should have nothing useful left, so `user2.delete`.

Eventually we can have a UI that selects duplicates and allows the administrator to choose which fields are the correct ones.

If there's a cleaner way to do this, please edit! :)