### PR TITLE
Random next and previous only show unvoted proposals

### DIFF
--- a/app/controllers/open_conference_ware/selector_votes_controller.rb
+++ b/app/controllers/open_conference_ware/selector_votes_controller.rb
@@ -46,7 +46,7 @@ module OpenConferenceWare
       respond_to do |format|
         if @selector_vote.save
           format.html {
-            if next_proposal = @selector_vote.proposal.next_random_proposal(current_user.id)
+            if next_proposal = @selector_vote.proposal.next_random_proposal(current_user.id, current_user.id)
               redirect_to(next_proposal)
             else
               flash[:success] = "You've voted on the last proposal!"

--- a/app/helpers/open_conference_ware/proposals_helper.rb
+++ b/app/helpers/open_conference_ware/proposals_helper.rb
@@ -36,7 +36,7 @@ module OpenConferenceWare
     # Return a path to the next proposal after +proposal+. Or none if none.
     def next_proposal_path_from(proposal)
       if selector?
-        next_proposal = proposal.next_random_proposal(current_user.id)
+        next_proposal = proposal.next_random_proposal(current_user.id, current_user.id)
       else
         next_proposal = proposal.next_proposal
       end

--- a/app/models/open_conference_ware/proposal.rb
+++ b/app/models/open_conference_ware/proposal.rb
@@ -530,7 +530,7 @@ module OpenConferenceWare
     def randomized_ids(seed = nil, user_id = nil)
       proposals = event.proposals.order_by_rand(seed: seed).find(:all)
       if user_id
-        new_proposals = proposals.filter { |p| p.has_voted?(user_id) }
+        new_proposals = proposals.select { |p| p.has_voted?(user_id) }
         # if all proposals have been voted on, then return a random one
         if new_proposals
           proposal = new_proposals
@@ -541,7 +541,7 @@ module OpenConferenceWare
 
     # return true if the user has voted for this proposal
     def has_voted?(user_id)
-      return self.selector_votes.filter { |v| v.user_id == user_id }.size > 0
+      return self.selector_votes.select { |v| v.user_id == user_id }.size > 0
     end
 
     # Return the integer sum of the selector votes rating for this proposal. Skips

--- a/app/models/open_conference_ware/proposal.rb
+++ b/app/models/open_conference_ware/proposal.rb
@@ -514,21 +514,34 @@ module OpenConferenceWare
       return self.event.proposals.where("id < ?", self.id).order("created_at DESC").first
     end
 
-    def next_random_proposal(seed = nil)
-      ids = randomized_ids(seed)
+    def next_random_proposal(seed = nil, user_id = nil)
+      ids = randomized_ids(seed, user_id)
       next_id = ids[ids.index(self.id) + 1]
       next_id && Proposal.find( next_id )
     end
 
-    def previous_random_proposal(seed = nil)
-      ids = randomized_ids(seed)
+    def previous_random_proposal(seed = nil, user_id = nil)
+      ids = randomized_ids(seed, user_id)
       prev_index = ids.index(self.id) - 1
       prev_id = ids[prev_index]
       prev_index >= 0 && prev_id && Proposal.find( prev_id )
     end
 
-    def randomized_ids(seed = nil)
-      event.proposals.order_by_rand(seed: seed).pluck(:id)
+    def randomized_ids(seed = nil, user_id = nil)
+      proposals = event.proposals.order_by_rand(seed: seed)
+      if user_id
+        new_proposals = proposals.filter { |p| p.has_voted?(user_id) }
+        # if all proposals have been voted on, then return a random one
+        if new_proposals
+          proposal = new_proposals
+        end
+      end
+      proposals.pluck(:id)
+    end
+
+    # return true if the user has voted for this proposal
+    def has_voted?(user_id)
+      return self.selector_votes.filter { |v| v.user_id == user_id }.size > 0
     end
 
     # Return the integer sum of the selector votes rating for this proposal. Skips

--- a/app/models/open_conference_ware/proposal.rb
+++ b/app/models/open_conference_ware/proposal.rb
@@ -528,7 +528,7 @@ module OpenConferenceWare
     end
 
     def randomized_ids(seed = nil, user_id = nil)
-      proposals = event.proposals.order_by_rand(seed: seed)
+      proposals = event.proposals.order_by_rand(seed: seed).find(:all)
       if user_id
         new_proposals = proposals.filter { |p| p.has_voted?(user_id) }
         # if all proposals have been voted on, then return a random one
@@ -536,7 +536,7 @@ module OpenConferenceWare
           proposal = new_proposals
         end
       end
-      proposals.pluck(:id)
+      proposals.map { |p| p.id }
     end
 
     # return true if the user has voted for this proposal


### PR DESCRIPTION
The purpose of this is so that selection committee members
can easily skip proposals they've already voted on.
Previously, they would see many duplicates, which can
be annoying.
